### PR TITLE
refactor: centralize gtf attribute parsing

### DIFF
--- a/src/flair_test_suite/qc/qc_utils.py
+++ b/src/flair_test_suite/qc/qc_utils.py
@@ -23,7 +23,7 @@
 from __future__ import annotations
 from pathlib import Path
 import subprocess
-from typing import Iterator
+from typing import Dict, Iterator
 
 import pysam
 from collections import Counter, defaultdict
@@ -33,6 +33,7 @@ import itertools
 __all__ = [
     "count_lines",
     "percent",
+    "parse_gtf_attributes",
     "iter_primary",
     "count_unique_junctions",
     "SAMPLE_LIMIT",
@@ -61,6 +62,28 @@ def percent(numerator: int, denominator: int, digits: int = 2) -> float:
     if denominator == 0:
         return 0.0
     return round(100 * numerator / denominator, digits)
+
+
+def parse_gtf_attributes(attr_col: str) -> Dict[str, str]:
+    """Return a dictionary mapping GTF attribute keys to values.
+
+    Parameters
+    ----------
+    attr_col : str
+        Raw attribute column from a GTF line, e.g. 'gene_id "g1"; transcript_id "t1";'
+
+    Returns
+    -------
+    Dict[str, str]
+        Mapping of attribute names to unquoted string values.
+    """
+    attrs: Dict[str, str] = {}
+    for chunk in attr_col.rstrip(";").split(";"):
+        chunk = chunk.strip()
+        if chunk and " " in chunk:
+            k, v = chunk.split(" ", 1)
+            attrs[k] = v.strip('"')
+    return attrs
 
 # ------------------------------------------------------------------
 # Streaming helper for large BAMs ----------------------------------

--- a/src/flair_test_suite/qc/regionalize_qc.py
+++ b/src/flair_test_suite/qc/regionalize_qc.py
@@ -12,20 +12,11 @@ from statistics import mean, median
 from typing import Any, Dict, List, Tuple, Iterator
 
 from . import register, write_metrics
-from .qc_utils import count_lines
+from .qc_utils import count_lines, parse_gtf_attributes
 
 __all__ = ["collect"]
 
 # ───────────────────────── GTF helpers ────────────────────────────────
-
-def _parse_attrs(attr_col: str) -> Dict[str, str]:
-    out: Dict[str, str] = {}
-    for chunk in attr_col.rstrip(";").split(";"):
-        chunk = chunk.strip()
-        if chunk and " " in chunk:
-            k, v = chunk.split(" ", 1)
-            out[k] = v.strip('"')
-    return out
 
 
 def _stream_gtf(gtf: Path) -> Iterator[List[str]]:
@@ -55,7 +46,7 @@ def _summarise_gtf(gtf: Path) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]
             s_i, e_i = int(s_s), int(e_s)
         except ValueError:
             continue
-        at = _parse_attrs(attrs)
+        at = parse_gtf_attributes(attrs)
         tid = at.get("transcript_id")
         gid = at.get("gene_id")
 

--- a/src/flair_test_suite/qc/slice_qc.py
+++ b/src/flair_test_suite/qc/slice_qc.py
@@ -4,7 +4,7 @@
 # Requirements:
 #  • Python standard library: csv, time, warnings, statistics, collections
 #  • pathlib, typing
-#  • qc_utils: count_lines
+#  • qc_utils: count_lines, parse_gtf_attributes
 #  • pipeline QC helpers: register, write_metrics
 #  • Optional for plots: pandas, numpy, plotly, scipy (install via mamba)
 # Summary:
@@ -20,8 +20,6 @@
 # Functions:
 #   collect(manifest, out_dir, runtime_sec)
 #       Main entry: orchestrates all QC steps for slice stage.
-#   _parse_attrs(attr_col)
-#       Parse GTF attribute column into dict.
 #   _stream_gtf(gtf)
 #       Yield non-header GTF fields as lists.
 #   _summarise_gtf(gtf)
@@ -40,26 +38,14 @@ import warnings
 from collections import defaultdict, Counter
 from pathlib import Path
 from statistics import mean, median
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Tuple, Iterator
 
 from . import register, write_metrics  # QC registry and output helper
-from .qc_utils import count_lines  # simple line counting utility
+from .qc_utils import count_lines, parse_gtf_attributes  # shared QC utilities
 
 __all__ = ["collect"]
 
 # ───────────────────────── GTF helpers ────────────────────────────────
-
-def _parse_attrs(attr_col: str) -> Dict[str, str]:
-    """
-    Convert a GTF attribute column into a key->value dict.
-    """
-    out: Dict[str, str] = {}
-    for chunk in attr_col.rstrip(";").split(";"):
-        chunk = chunk.strip()
-        if chunk and " " in chunk:
-            k, v = chunk.split(" ", 1)
-            out[k] = v.strip('"')
-    return out
 
 
 def _stream_gtf(gtf: Path) -> Iterator[List[str]]:
@@ -96,7 +82,7 @@ def _summarise_gtf(gtf: Path) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]
             s_i, e_i = int(s_s), int(e_s)
         except ValueError:
             continue
-        at = _parse_attrs(attrs)
+        at = parse_gtf_attributes(attrs)
         tid = at.get("transcript_id")
         gid = at.get("gene_id")
 


### PR DESCRIPTION
## Summary
- consolidate GTF attribute parsing into `parse_gtf_attributes`
- use shared parser in slice and regionalize QC collectors to remove duplication

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d0ccc0de08327b8a11cc1ff207692