### PR TITLE
Refactor stage command builders with shared utility

### DIFF
--- a/src/flair_test_suite/stages/align.py
+++ b/src/flair_test_suite/stages/align.py
@@ -12,7 +12,7 @@ from pathlib import Path # for filesystem paths
 
 from .base import StageBase       # base class providing orchestration logic
 
-from .stage_utils import count_reads
+from .stage_utils import count_reads, make_flair_cmd
 
 class AlignStage(StageBase):
     """
@@ -65,14 +65,13 @@ class AlignStage(StageBase):
 
         # --- construct and return the final command list ---
         out_prefix = f"{self.run_id}_flair"
-        cmd = [
-            "flair", "align",
-            "-g", str(genome),
-            "-r", str(reads),
-            "-o", out_prefix,
-            *flag_parts,
-        ]
-        return cmd
+        return make_flair_cmd(
+            "align",
+            genome=genome,
+            reads=reads,
+            out=out_prefix,
+            flags=flag_parts,
+        )
 
     @property
     def tool_version(self) -> str:

--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -8,7 +8,7 @@ from typing import List, Tuple
 from .base import StageBase
 from ..qc.qc_utils import count_lines
 from ..qc import write_metrics
-from .stage_utils import read_region_details
+from .stage_utils import read_region_details, make_flair_cmd
 ...
 # Force-load TED QC so Reinstate knows transcriptome has QC
 try:
@@ -117,27 +117,29 @@ class CollapseStage(StageBase):
 
         if mode == "regionalized":
             for bed, tag in bed_pairs:
-                cmd = [
-                    "flair", "collapse",
-                    "-q", str(bed),
-                    "-g", str(genome),
-                    "-r", *map(str, reads),
-                    "-o", tag,
-                    *flag_parts,
-                ]
-                cmds.append(cmd)
+                cmds.append(
+                    make_flair_cmd(
+                        "collapse",
+                        bed=bed,
+                        genome=genome,
+                        reads=reads,
+                        out=tag,
+                        flags=flag_parts,
+                    )
+                )
                 logging.info(f"[collapse] Scheduled per-region collapse: {tag}")
         else:
             bed, _ = bed_pairs[0]
-            cmd = [
-                "flair", "collapse",
-                "-q", str(bed),
-                "-g", str(genome),
-                "-r", *map(str, reads),
-                "-o", self.run_id,
-                *flag_parts,
-            ]
-            cmds.append(cmd)
+            cmds.append(
+                make_flair_cmd(
+                    "collapse",
+                    bed=bed,
+                    genome=genome,
+                    reads=reads,
+                    out=self.run_id,
+                    flags=flag_parts,
+                )
+            )
             logging.info(f"[collapse] Scheduled standard collapse: {self.run_id}")
 
         logging.debug(f"[collapse] mode={mode} commands={len(cmds)}")

--- a/src/flair_test_suite/stages/stage_utils.py
+++ b/src/flair_test_suite/stages/stage_utils.py
@@ -21,6 +21,45 @@ def resolve_path(raw: str | Path, *, data_dir: Path) -> Path:
     p = Path(raw)
     return p if p.is_absolute() else (data_dir / p).resolve()
 
+
+def make_flair_cmd(
+    subcmd: str,
+    *,
+    genome: Path | str | None = None,
+    reads: Iterable[Path | str] | Path | str | None = None,
+    bed: Path | str | None = None,
+    bam: Path | str | None = None,
+    out: Path | str | None = None,
+    flags: Iterable[str] | None = None,
+) -> List[str]:
+    """Return a FLAIR command list with common -g/-r/-q/-b/-o options."""
+
+    cmd: List[str] = ["flair", subcmd]
+
+    if genome:
+        cmd.extend(["-g", str(genome)])
+
+    if reads:
+        if isinstance(reads, (str, Path)):
+            cmd.extend(["-r", str(reads)])
+        else:
+            cmd.append("-r")
+            cmd.extend(str(r) for r in reads)
+
+    if bed:
+        cmd.extend(["-q", str(bed)])
+
+    if bam:
+        cmd.extend(["-b", str(bam)])
+
+    if out:
+        cmd.extend(["-o", str(out)])
+
+    if flags:
+        cmd.extend(list(flags))
+
+    return cmd
+
 # ── flag parsing helpers -------------------------------------------
 
 def iter_stage_flags(flags_block) -> Iterator[Tuple[str, object]]:

--- a/src/flair_test_suite/stages/transcriptome.py
+++ b/src/flair_test_suite/stages/transcriptome.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import List, Tuple
 
 from .base import StageBase
-from .stage_utils import read_region_details
+from .stage_utils import read_region_details, make_flair_cmd
 class TranscriptomeStage(StageBase):
     """
     FLAIR transcriptome stage (v3+)
@@ -125,26 +125,28 @@ class TranscriptomeStage(StageBase):
         if mode == "regionalized":
             # One transcriptome call per region
             for bam, tag in bam_pairs:
-                cmd = [
-                    "flair", "transcriptome",
-                    "-b", str(bam),
-                    "-g", str(genome),
-                    "-o", tag,
-                    *flag_parts,
-                ]
-                cmds.append(cmd)
+                cmds.append(
+                    make_flair_cmd(
+                        "transcriptome",
+                        bam=bam,
+                        genome=genome,
+                        out=tag,
+                        flags=flag_parts,
+                    )
+                )
                 logging.info(f"[transcriptome] Scheduled per-region transcriptome: {tag}")
         else:
             # Single standard call
             bam, _ = bam_pairs[0]
-            cmd = [
-                "flair", "transcriptome",
-                "-b", str(bam),
-                "-g", str(genome),
-                "-o", self.run_id,
-                *flag_parts,
-            ]
-            cmds.append(cmd)
+            cmds.append(
+                make_flair_cmd(
+                    "transcriptome",
+                    bam=bam,
+                    genome=genome,
+                    out=self.run_id,
+                    flags=flag_parts,
+                )
+            )
             logging.info(f"[transcriptome] Scheduled standard transcriptome: {self.run_id}")
 
         logging.debug(f"[transcriptome] mode={mode} commands={len(cmds)}")


### PR DESCRIPTION
## Summary
- add `make_flair_cmd` helper for assembling FLAIR CLI calls
- simplify stage `build_cmd`/`build_cmds` by using shared helper
- factor BED discovery in Correct stage into `_resolve_bed_files`

## Testing
- `python -m py_compile src/flair_test_suite/stages/stage_utils.py src/flair_test_suite/stages/align.py src/flair_test_suite/stages/correct.py src/flair_test_suite/stages/collapse.py src/flair_test_suite/stages/transcriptome.py`

------
https://chatgpt.com/codex/tasks/task_e_689e19bd8f508327820d314b3e5b2a0d