### PR TITLE
Add placeholder tests for stage and QC modules

### DIFF
--- a/tests/test_qc_dummy.py
+++ b/tests/test_qc_dummy.py
@@ -1,0 +1,28 @@
+import pytest
+from pathlib import Path
+import sys
+
+# Make package importable and skip if heavy QC deps missing
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+pytest.importorskip("pysam")
+pytest.importorskip("matplotlib")
+
+from flair_test_suite import qc
+
+
+def test_qc_registry_has_expected_collectors():
+    expected = {"align", "correct", "regionalize", "ted"}
+    assert expected <= set(qc.QC_REGISTRY)
+    for func in qc.QC_REGISTRY.values():
+        assert callable(func)
+
+
+def test_write_metrics_creates_tsv(tmp_path: Path):
+    metrics = {"one": 1, "two": "dos"}
+    qc.write_metrics(tmp_path, "dummy", metrics)
+    out = tmp_path / "dummy_qc.tsv"
+    assert out.exists()
+    lines = out.read_text().splitlines()
+    assert lines[0] == "metric\tvalue"
+    assert "one\t1" in lines[1:]
+    assert "two\tdos" in lines[1:]

--- a/tests/test_stage_registry.py
+++ b/tests/test_stage_registry.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+import types
+import sys
+import importlib
+import pytest
+
+# Ensure package imports resolve without installation
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+# Skip if heavy QC deps needed by stage imports are missing
+pytest.importorskip("pysam")
+pytest.importorskip("matplotlib")
+
+# Reload the real stages package in case other tests stubbed it
+sys.modules.pop("flair_test_suite.stages", None)
+stages_pkg = importlib.import_module("flair_test_suite.stages")
+from flair_test_suite.stages.base import StageBase
+STAGE_REGISTRY = stages_pkg.STAGE_REGISTRY
+
+
+def test_stage_registry_contains_expected_classes():
+    """Ensure shipped stages are registered with their names."""
+    expected = {"align", "correct", "regionalize", "collapse", "transcriptome"}
+    assert expected <= STAGE_REGISTRY.keys()
+
+    dummy_cfg = types.SimpleNamespace(run=types.SimpleNamespace(data_dir=".", conda_env="env"))
+    for name in expected:
+        cls = STAGE_REGISTRY[name]
+        assert issubclass(cls, StageBase)
+        stage = cls(dummy_cfg, run_id="demo", work_dir=Path("/tmp"), upstreams={})
+        assert stage.name == name
+        assert hasattr(stage, "primary_output_key")


### PR DESCRIPTION
## Summary
- add dummy tests ensuring stage registry exposes expected classes
- add dummy tests verifying QC registry and metrics writer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e1d3c40008327a17612d52040a32c