### PR TITLE
Add regional plotting option and dataclass config to genome browser

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,8 @@ dependencies    = [
   "colorama>=0.4.6",
   "python-dateutil>=2.9.0.post0",
   "typing-extensions>=4.14.1",
-  "packaging>=25.0"
+  "packaging>=25.0",
+  "intervaltree>=3.1.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- refactor transcriptome_browser to use a typed `Config` dataclass and Pathlib
- add optional `--region` argument with 20 kb size guard and safer BAM handling
- batch histogram drawing and make isoform KDE optional
- add `intervaltree` to project dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e2699524c8327b100e25fc59c2a75