### PR TITLE
fix: resolve data_dir for non-regionalized TED

### DIFF
--- a/src/flair_test_suite/qc/ted.py
+++ b/src/flair_test_suite/qc/ted.py
@@ -415,7 +415,12 @@ def collect(stage_dir: Path, cfg) -> None:
                 cur = cur.get(k, {}) if isinstance(cur, dict) else {}
             return cur if cur != {} else default
 
-    data_dir = Path(_cfg_get(["run", "data_dir"], "."))
+    data_dir_cfg = Path(_cfg_get(["run", "data_dir"], "."))
+    if data_dir_cfg.is_absolute():
+        data_dir = data_dir_cfg
+    else:
+        repo_root = stage_dir.parent.parent.parent
+        data_dir = (repo_root / data_dir_cfg).resolve()
     logging.debug(f"[TED] Data directory set to: {data_dir}")
 
     # Optional QC block


### PR DESCRIPTION
## Summary
- resolve `data_dir` relative to repository root when evaluating non-regionalized runs
- ensure 5'/3' prime peak files can be located for TED QC

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e2cd48e988327bc29b4aae1d21991