### PR TITLE
fix: avoid huge transcriptome browser images

### DIFF
--- a/src/flair_test_suite/plotting/transcriptome_browser.py
+++ b/src/flair_test_suite/plotting/transcriptome_browser.py
@@ -572,7 +572,12 @@ def generate(cfg: Config, region: Optional[str] = None) -> None:
 
     # save
     out_png = outdir / f"{genome}_{contig}_{rs}-{re_}.png"
-    fig.savefig(out_png, bbox_inches='tight')
+    # ``bbox_inches='tight'`` can drastically enlarge the exported PNG when
+    # any artist lies outside the plot limits.  This resulted in images with
+    # widths in the hundreds of thousands of pixels.  Saving without the
+    # "tight" bounding box preserves the intended figure dimensions so the
+    # reported size matches the actual file.
+    fig.savefig(out_png, dpi=fig.dpi)
     plt.close(fig)
     width_px, height_px = int(fig_w * fig.dpi), int(fig_h * fig.dpi)
     print(f"Figure dimensions: {width_px} x {height_px} pixels")


### PR DESCRIPTION
## Summary
- avoid use of `bbox_inches='tight'` when saving transcriptome browser plot
- prevent massive PNG output and report correct figure dimensions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e34356370832796ccabc4777348b7