### PR TITLE
Integrate TED QC with transcriptome stage and fix precision/recall bug

### DIFF
--- a/src/flair_test_suite/qc/ted.py
+++ b/src/flair_test_suite/qc/ted.py
@@ -103,7 +103,9 @@ def _vectorized_overlap_counts(bed_df: pd.DataFrame, peaks_df: pd.DataFrame, win
     """Return (#peaks matched by ≥1 isoform within window, total peaks)."""
     consumed = np.zeros(len(peaks_df), dtype=bool)
     for (c, s), chunk in bed_df.groupby(["Chrom", "Strand"], sort=False):
-        mask = (peaks_df["Chrom"] == c) & (peaks_df["Strand"] == s)
+        mask = (peaks_df["Chrom"] == c) & (
+            (peaks_df["Strand"] == s) | (peaks_df["Strand"] == ".")
+        )
         idxs = np.flatnonzero(mask)
         if idxs.size == 0:
             continue
@@ -384,6 +386,7 @@ def _tss_tts_metrics_full(iso_bed: Path, peaks: Dict[str, Optional[Path]], windo
 # ────────────────────────── main collector ──────────────────────────
 @register("TED")
 @register("collapse")
+@register("transcriptome")
 def collect(stage_dir: Path, cfg) -> None:
     """
     Writes:

--- a/tests/test_qc_dummy.py
+++ b/tests/test_qc_dummy.py
@@ -11,7 +11,7 @@ from flair_test_suite import qc
 
 
 def test_qc_registry_has_expected_collectors():
-    expected = {"align", "correct", "regionalize", "ted"}
+    expected = {"align", "correct", "regionalize", "ted", "transcriptome"}
     assert expected <= set(qc.QC_REGISTRY)
     for func in qc.QC_REGISTRY.values():
         assert callable(func)


### PR DESCRIPTION
## Summary
- allow strand-agnostic peak matching in TED to correctly compute precision/recall
- register TED QC for transcriptome stage and run it after transcriptome
- document transcriptome QC in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e65bd5c608327b42f5ef2a45996dd