### PR TITLE
Handle reads lacking collapsed isoform in transcriptome browser

### DIFF
--- a/src/flair_test_suite/plotting/transcriptome_browser.py
+++ b/src/flair_test_suite/plotting/transcriptome_browser.py
@@ -375,6 +375,10 @@ def generate(cfg: Config, region: Optional[str] = None) -> None:
             st, en = int(row.start), int(row.end)
         if st is None:
             logging.warning(f"No collapsed bar for {iso}")
+            # Treat reads from this isoform as unassigned so they can
+            # still be displayed rather than leaving their rows as None
+            # (which causes errors later when computing layout).
+            unassigned.extend(idxs)
             continue
 
         left = min(reads_blocks[j][0][0] for j in idxs)


### PR DESCRIPTION
## Summary
- Prevent `None` row assignments when an isoform lacks a collapsed bar in the transcriptome browser
- Treat reads from such isoforms as unassigned to avoid crashes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e69a2cbb08327bff5f02fda14edb0