### PR TITLE
fix: expand data paths and audit missing TED peaks

### DIFF
--- a/tests/test_ted_missing_peaks.py
+++ b/tests/test_ted_missing_peaks.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from flair_test_suite.qc.ted import _tss_tts_metrics_full
+
+
+def test_tss_tts_metrics_full_audits_missing(tmp_path):
+    iso = tmp_path / 'iso.bed'
+    iso.write_text('chr1\t0\t1\tiso1\t0\t+\n')
+    audit = []
+    peaks = {'prime5': None, 'prime3': None, 'ref_prime5': None, 'ref_prime3': None}
+    metrics = _tss_tts_metrics_full(iso, peaks, 50, audit, 'ctx')
+    assert metrics['5prime_precision'] is None
+    assert len(audit) == 4
+    notes = {row['note'] for row in audit}
+    assert notes == {'missing'}
+    tags = {row['tag'] for row in audit}
+    assert tags == {'5', '3', 'ref5', 'ref3'}

--- a/tests/test_ted_regionalized.py
+++ b/tests/test_ted_regionalized.py
@@ -1,0 +1,87 @@
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from flair_test_suite.qc import ted
+
+
+def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
+    repo_root = tmp_path
+    data_dir = repo_root / 'test_data'
+    data_dir.mkdir()
+    for name in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
+        (data_dir / name).write_text('chr1\t0\t1\t.\t0\t+\n')
+
+    run_id = 'run1'
+    stage_uuid = '123abc'
+    stage_dir = repo_root / 'outputs' / run_id / 'collapse' / stage_uuid
+    stage_dir.mkdir(parents=True)
+
+    tag = 'chr1_0_100'
+    iso_bed = stage_dir / f'{tag}.isoforms.bed'
+    iso_bed.write_text('chr1\t10\t50\tread_ENSG000001.1\t0\t+\n')
+    map_txt = stage_dir / f'{tag}.isoform.read.map.txt'
+    map_txt.write_text(f'{iso_bed.stem}\tread1\n')
+
+    corr_dir = repo_root / 'outputs' / run_id / 'correct' / 'abcd'
+    corr_dir.mkdir(parents=True)
+    (corr_dir / f'{tag}_all_corrected.bed').write_text('chr1\t10\t50\tread_ENSG000001.1\t0\t+\n')
+
+    reg_dir = repo_root / 'outputs' / run_id / 'regionalize' / 'reg1'
+    reg_dir.mkdir(parents=True)
+    (reg_dir / 'region_metrics.tsv').write_text('region_tag\tgene_count\ttranscript_count\nchr1_0_100\t1\t1\n')
+    for base in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
+        (reg_dir / f'{tag}_{base}').write_text('chr1\t10\t20\t.\t0\t+\n')
+
+    cfg = {
+        'run': {'data_dir': 'test_data'},
+        'qc': {
+            'collapse': {
+                'TED': {
+                    'experiment_5_prime_regions_bed_file': 'exp5.bed',
+                    'experiment_3_prime_regions_bed_file': 'exp3.bed',
+                    'reference_5_prime_regions_bed_file': 'ref5.bed',
+                    'reference_3_prime_regions_bed_file': 'ref3.bed',
+                    'window': 10,
+                }
+            }
+        },
+    }
+
+    captured = {}
+
+    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
+        captured.update(peaks)
+        return {
+            '5prime_precision': 0.1,
+            '5prime_recall': 0.1,
+            '5prime_f1': 0.1,
+            '3prime_precision': 0.2,
+            '3prime_recall': 0.2,
+            '3prime_f1': 0.2,
+            'ref5prime_precision': 0.3,
+            'ref5prime_recall': 0.3,
+            'ref5prime_f1': 0.3,
+            'ref3prime_precision': 0.4,
+            'ref3prime_recall': 0.4,
+            'ref3prime_f1': 0.4,
+        }
+
+    monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
+
+    ted.collect(stage_dir, cfg)
+
+    assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
+    assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
+    assert captured['ref_prime5'] == reg_dir / f'{tag}_ref5.bed'
+    assert captured['ref_prime3'] == reg_dir / f'{tag}_ref3.bed'
+
+    df = pd.read_csv(stage_dir / 'TED.tsv', sep='\t')
+    assert df.loc[0, '5prime_precision'] == 0.1
+    assert df.loc[0, '3prime_precision'] == 0.2
+    assert df.loc[0, 'ref5prime_precision'] == 0.3
+    assert df.loc[0, 'ref3prime_precision'] == 0.4

--- a/tests/test_ted_resolve.py
+++ b/tests/test_ted_resolve.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from flair_test_suite.qc.ted import _resolve
+
+
+def test_resolve_expands_env_and_user(tmp_path, monkeypatch):
+    monkeypatch.setenv('DATA_HOME', str(tmp_path))
+    # env var expansion
+    p = _resolve('${DATA_HOME}/file.bed', Path('/unused'))
+    assert p == tmp_path / 'file.bed'
+
+    # user expansion
+    monkeypatch.setenv('HOME', str(tmp_path))
+    p2 = _resolve('~/another.bed', Path('/unused'))
+    assert p2 == tmp_path / 'another.bed'


### PR DESCRIPTION
## Summary
- expand `_resolve` to honor environment variables and `~` so TED can find peak files
- audit missing TSS/TTS peak files and skip silently computing precision/recall only when files resolve
- add regression tests for path resolution, missing peak auditing, and regionalized precision metrics

## Testing
- `pytest tests/test_ted_resolve.py tests/test_ted_missing_peaks.py tests/test_ted_regionalized.py tests/test_ted_nonregionalized.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a64d67b3888327b30b833bdbc0bbd9