### PR TITLE
Fix TED peak path resolution and add flag-based config fallback

### DIFF
--- a/tests/test_ted_nonregionalized.py
+++ b/tests/test_ted_nonregionalized.py
@@ -81,3 +81,52 @@ def test_collect_single_resolves_peaks(tmp_path: Path, monkeypatch):
     assert df.loc[0, "3prime_precision"] == 0.2
     assert df.loc[0, "ref5prime_precision"] == 0.3
     assert df.loc[0, "ref3prime_precision"] == 0.4
+
+
+def test_collect_single_uses_stage_flags(tmp_path: Path, monkeypatch):
+    """If the QC block omits peak paths, fall back to run.stage flags."""
+    repo_root = tmp_path
+    data_dir = repo_root / "test_data"
+    data_dir.mkdir()
+    for name in ["exp5.bed", "exp3.bed", "ref5.bed", "ref3.bed"]:
+        (data_dir / name).write_text("chr1\t0\t1\t.\t0\t+\n")
+
+    run_id = "run1"
+    stage_uuid = "123abc"
+    stage_dir = repo_root / "outputs" / run_id / "collapse" / stage_uuid
+    stage_dir.mkdir(parents=True)
+
+    iso_bed = stage_dir / f"{run_id}.isoforms.bed"
+    iso_bed.write_text("chr1\t100\t200\tread_ENSG000001.1\t0\t+\n")
+
+    cfg = {
+        "run": {
+            "data_dir": "test_data",
+            "stages": {
+                "collapse": {
+                    "flags": {
+                        "experiment_5_prime_regions_bed_file": "exp5.bed",
+                        "experiment_3_prime_regions_bed_file": "exp3.bed",
+                        "reference_5_prime_regions_bed_file": "ref5.bed",
+                        "reference_3_prime_regions_bed_file": "ref3.bed",
+                    }
+                }
+            },
+        },
+        "qc": {"collapse": {"TED": {"window": 10}}},
+    }
+
+    captured = {}
+
+    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
+        captured.update(peaks)
+        return {}
+
+    monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
+
+    ted.collect(stage_dir, cfg)
+
+    assert captured["prime5"] == data_dir / "exp5.bed"
+    assert captured["prime3"] == data_dir / "exp3.bed"
+    assert captured["ref_prime5"] == data_dir / "ref5.bed"
+    assert captured["ref_prime3"] == data_dir / "ref3.bed"

--- a/tests/test_ted_regionalized.py
+++ b/tests/test_ted_regionalized.py
@@ -85,3 +85,59 @@ def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
     assert df.loc[0, '3prime_precision'] == 0.2
     assert df.loc[0, 'ref5prime_precision'] == 0.3
     assert df.loc[0, 'ref3prime_precision'] == 0.4
+
+
+def test_collect_regionalized_uses_stage_flags(tmp_path: Path, monkeypatch):
+    """When QC config omits peaks, run.stage flags supply them."""
+    repo_root = tmp_path
+    data_dir = repo_root / 'test_data'
+    data_dir.mkdir()
+    for name in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
+        (data_dir / name).write_text('chr1\t0\t1\t.\t0\t+\n')
+
+    run_id = 'run1'
+    stage_uuid = '123abc'
+    stage_dir = repo_root / 'outputs' / run_id / 'collapse' / stage_uuid
+    stage_dir.mkdir(parents=True)
+
+    tag = 'chr1_0_100'
+    iso_bed = stage_dir / f'{tag}.isoforms.bed'
+    iso_bed.write_text('chr1\t10\t50\tread_ENSG000001.1\t0\t+\n')
+
+    reg_dir = repo_root / 'outputs' / run_id / 'regionalize' / 'reg1'
+    reg_dir.mkdir(parents=True)
+    (reg_dir / 'region_metrics.tsv').write_text('region_tag\tgene_count\ttranscript_count\nchr1_0_100\t1\t1\n')
+    for base in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
+        (reg_dir / f'{tag}_{base}').write_text('chr1\t10\t20\t.\t0\t+\n')
+
+    cfg = {
+        'run': {
+            'data_dir': 'test_data',
+            'stages': {
+                'collapse': {
+                    'flags': {
+                        'experiment_5_prime_regions_bed_file': 'exp5.bed',
+                        'experiment_3_prime_regions_bed_file': 'exp3.bed',
+                        'reference_5_prime_regions_bed_file': 'ref5.bed',
+                        'reference_3_prime_regions_bed_file': 'ref3.bed',
+                    }
+                }
+            },
+        },
+        'qc': {'collapse': {'TED': {'window': 10}}},
+    }
+
+    captured = {}
+
+    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
+        captured.update(peaks)
+        return {}
+
+    monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
+
+    ted.collect(stage_dir, cfg)
+
+    assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
+    assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
+    assert captured['ref_prime5'] == reg_dir / f'{tag}_ref5.bed'
+    assert captured['ref_prime3'] == reg_dir / f'{tag}_ref3.bed'


### PR DESCRIPTION
## Summary
- ensure `TED` resolves `data_dir` relative to repo root and unify config access
- support peak file paths defined in `run.stages.<stage>.flags`
- add regression tests for flag-based peak resolution in regionalized and non-regionalized runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a653a39fa48327b6af91cd3b60cb52