### PR TITLE
Ensure TED uses regionalize PathBuilder

### DIFF
--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -175,7 +175,7 @@ class CollapseStage(StageBase):
         qc: dict = {}
         try:
             from ..qc.ted import collect as ted_collect
-            ted_collect(stage_dir, self.cfg)
+            ted_collect(stage_dir, self.cfg, upstreams=self.upstreams)
             qc["TED"] = {"tsv": str(stage_dir / "TED.tsv")}
         except Exception as e:
             logging.warning(f"[transcriptome] TED QC failed: {e}")

--- a/src/flair_test_suite/stages/transcriptome.py
+++ b/src/flair_test_suite/stages/transcriptome.py
@@ -189,7 +189,7 @@ class TranscriptomeStage(StageBase):
         qc: dict = {}
         try:
             from ..qc.ted import collect as ted_collect
-            ted_collect(stage_dir, self.cfg)
+            ted_collect(stage_dir, self.cfg, upstreams=self.upstreams)
             qc["TED"] = {"tsv": str(stage_dir / "TED.tsv")}
         except Exception as e:  # pragma: no cover - logging only
             logging.warning(f"[transcriptome] TED QC failed: {e}")

--- a/tests/test_ted_nonregionalized.py
+++ b/tests/test_ted_nonregionalized.py
@@ -1,11 +1,15 @@
 import sys
 from pathlib import Path
+import types
 
 import pandas as pd
 import pytest
 
 # Make package importable
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+sys.modules.setdefault("intervaltree", types.SimpleNamespace(IntervalTree=object))
+sys.modules.setdefault("pysam", types.SimpleNamespace(AlignedSegment=object))
 
 from flair_test_suite.qc import ted
 

--- a/tests/test_ted_regionalized.py
+++ b/tests/test_ted_regionalized.py
@@ -1,12 +1,17 @@
 import sys
 from pathlib import Path
+import types
 
 import pandas as pd
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
 
+sys.modules.setdefault('intervaltree', types.SimpleNamespace(IntervalTree=object))
+sys.modules.setdefault('pysam', types.SimpleNamespace(AlignedSegment=object))
+
 from flair_test_suite.qc import ted
+from flair_test_suite.lib import PathBuilder
 
 
 def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
@@ -73,7 +78,8 @@ def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
 
-    ted.collect(stage_dir, cfg)
+    reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
+    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb})
 
     assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
     assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
@@ -135,7 +141,8 @@ def test_collect_regionalized_uses_stage_flags(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
 
-    ted.collect(stage_dir, cfg)
+    reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
+    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb})
 
     assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
     assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'


### PR DESCRIPTION
## Summary
- pass regionalize stage PathBuilder to TED QC
- scope region metrics index to the provided regionalize directory
- adjust tests for regionalized runs to supply upstream PathBuilder

## Testing
- `pytest tests/test_ted_regionalized.py -q`
- `pytest tests/test_ted_nonregionalized.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a74eeccdc083278f7f1c4a43f38480