### PR TITLE
Fix Reinstate skip for TED QC stages

### DIFF
--- a/src/flair_test_suite/lib/reinstate.py
+++ b/src/flair_test_suite/lib/reinstate.py
@@ -39,22 +39,29 @@ class Reinstate:
         "run"   – otherwise run the external tool
         """
         marker_f = stage_dir / ".completed.json"
-        qc_tsv   = qc_sidecar_path(stage_dir, stage_name)
         marker_ok = marker_f.exists()
         primary_ok = primary.exists()
 
-        # For QC: need side‑car TSV *and* a "qc" block in marker
-        if needs_qc:
+        if needs_qc and stage_name in {"collapse", "transcriptome"}:
+            ted_tsv = stage_dir / "TED.tsv"
+            browser_dir = stage_dir / "transcriptome_browser"
+            browser_png = None
+            if browser_dir.exists():
+                browser_png = next(browser_dir.glob("*.png"), None)
+            qc_ok = ted_tsv.exists() and browser_png is not None
+            qc_desc = f"TED.tsv {'found' if ted_tsv.exists() else 'missing'}, browser plot {'found' if browser_png else 'missing'}"
+        elif needs_qc:
             qc_tsv = qc_sidecar_path(stage_dir, stage_name)
-            # trust the TSV file, regardless of marker content
             qc_ok = qc_tsv.exists()
+            qc_desc = f"{qc_tsv} exists? {qc_ok}"
         else:
             qc_ok = True
+            qc_desc = "n/a"
 
         print(f"[Reinstate] Stage: {stage_name}")
         print(f"  Marker: {marker_f} exists? {marker_ok}")
         print(f"  Primary: {primary} exists? {primary_ok}")
-        print(f"  QC: {qc_tsv} exists? {qc_ok}")
+        print(f"  QC: {qc_desc}")
         print(f"  All files in {stage_dir}: {list(stage_dir.iterdir())}")
 
         if marker_ok and primary_ok and qc_ok:

--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -7,7 +7,6 @@ from typing import List, Tuple
 
 from .base import StageBase
 from ..qc.qc_utils import bed_is_empty
-from ..qc import write_metrics
 from .stage_utils import read_region_details, make_flair_cmd
 ...
 # Force-load TED QC so Reinstate knows transcriptome has QC
@@ -170,8 +169,10 @@ class CollapseStage(StageBase):
         qc: dict = {}
         try:
             from ..qc.ted import collect as ted_collect
+
             ted_collect(stage_dir, self.cfg, upstreams=self.upstreams)
             qc["TED"] = {"tsv": str(stage_dir / "TED.tsv")}
+
         except Exception as e:
-            logging.warning(f"[transcriptome] TED QC failed: {e}")
+            logging.warning(f"[collapse] TED QC failed: {e}")
         return qc

--- a/src/flair_test_suite/stages/transcriptome.py
+++ b/src/flair_test_suite/stages/transcriptome.py
@@ -189,8 +189,10 @@ class TranscriptomeStage(StageBase):
         qc: dict = {}
         try:
             from ..qc.ted import collect as ted_collect
+
             ted_collect(stage_dir, self.cfg, upstreams=self.upstreams)
             qc["TED"] = {"tsv": str(stage_dir / "TED.tsv")}
+
         except Exception as e:  # pragma: no cover - logging only
             logging.warning(f"[transcriptome] TED QC failed: {e}")
         return qc

--- a/tests/test_reinstate_ted_qc.py
+++ b/tests/test_reinstate_ted_qc.py
@@ -1,0 +1,51 @@
+import sys
+import types
+from pathlib import Path
+
+# Make package importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+sys.modules.pop("flair_test_suite", None)
+sys.modules.pop("flair_test_suite.stages", None)
+
+from flair_test_suite.stages import CollapseStage, TranscriptomeStage
+from flair_test_suite.lib.reinstate import Reinstate
+
+
+def _setup_stage(stage_cls, stage_name, tmp_path, monkeypatch, make_browser=True):
+    stage_dir = tmp_path / "out" / "run1" / stage_name / "sig"
+    stage_dir.mkdir(parents=True)
+    primary = stage_dir / "run1.isoforms.bed"
+    primary.write_text("chr1\t0\t1\tread\t0\t+\n")
+
+    def fake_collect(stage_dir, cfg, upstreams=None):
+        (stage_dir / "TED.tsv").write_text("col1\tcol2\n")
+        if make_browser:
+            br = stage_dir / "transcriptome_browser"
+            br.mkdir()
+            (br / "dummy.png").write_text("png")
+
+    import flair_test_suite.qc.ted as ted_mod
+    monkeypatch.setattr(ted_mod, "collect", fake_collect)
+
+    cfg = types.SimpleNamespace(run=types.SimpleNamespace(version="3.0.0"))
+    stage = stage_cls(cfg, "run1", tmp_path, upstreams={})
+    stage._run_qc(stage_dir, primary, runtime=None)
+    (stage_dir / ".completed.json").write_text("{}")
+    action = Reinstate.decide(stage_dir, primary, needs_qc=True, stage_name=stage_name)
+    return action
+
+
+def test_collapse_reinstate(tmp_path, monkeypatch):
+    action = _setup_stage(CollapseStage, "collapse", tmp_path, monkeypatch)
+    assert action == "skip"
+
+
+def test_transcriptome_reinstate(tmp_path, monkeypatch):
+    action = _setup_stage(TranscriptomeStage, "transcriptome", tmp_path, monkeypatch)
+    assert action == "skip"
+
+
+def test_missing_browser_triggers_qc(tmp_path, monkeypatch):
+    action = _setup_stage(CollapseStage, "collapse", tmp_path, monkeypatch, make_browser=False)
+    assert action == "qc"
+


### PR DESCRIPTION
## Summary
- rely on TED.tsv and transcriptome browser plot to determine QC completeness for collapse/transcriptome stages
- drop stage-specific QC sidecars and update Reinstate logic
- add regression tests for plot-aware Reinstate decisions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75d3dff6883278fdfac8d756e5514