### PR TITLE
refactor stage utilities, unify stage behaviors

### DIFF
--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -7,8 +7,12 @@ from typing import List, Tuple
 
 from .base import StageBase
 from ..qc.qc_utils import bed_is_empty
-from .stage_utils import read_region_details, make_flair_cmd
-...
+from .stage_utils import (
+    collect_upstream_pairs,
+    build_flair_cmds,
+    isoform_expected_outputs,
+    run_ted_qc,
+)
 # Force-load TED QC so Reinstate knows transcriptome has QC
 try:
     from ..qc import ted as _force_import_ted  # noqa: F401
@@ -35,46 +39,14 @@ class CollapseStage(StageBase):
     _first_tag: str | None = None
 
     def _collect_corrected_inputs(self) -> Tuple[List[Tuple[Path, str]], List[Path], str]:
-        if "correct" not in self.upstreams:
-            raise RuntimeError("collapse requires upstream `correct` stage.")
-
-        corr_pb = self.upstreams["correct"]
-        corr_dir = corr_pb.stage_dir
-        upstream_sigs: List[Path] = [corr_pb.signature]
-
-        pairs: List[Tuple[Path, str]] = []
-
-        if "regionalize" in self.upstreams:
-            mode = "regionalized"
-            reg_pb = self.upstreams["regionalize"]
-            upstream_sigs.append(reg_pb.signature)
-
-            details = reg_pb.stage_dir / "region_details.tsv"
-            if not details.exists():
-                raise RuntimeError(f"Expected region_details.tsv not found: {details}")
-
-            for chrom, start, end in read_region_details(details):
-                tag = f"{chrom}_{start}_{end}"
-                bed = corr_dir / f"{tag}_all_corrected.bed"
-                if bed_is_empty(bed):
-                    logging.warning(
-                        f"[collapse] Missing or empty corrected BED, skipping: {bed}"
-                    )
-                    continue
-                pairs.append((bed, tag))
-        else:
-            mode = "standard"
-            bed = corr_dir / f"{self.run_id}_all_corrected.bed"
-            if not bed.exists():
-                raise RuntimeError(f"Expected corrected BED not found: {bed}")
-            if bed_is_empty(bed):
-                raise RuntimeError(f"Corrected BED is empty: {bed}")
-            pairs.append((bed, self.run_id))
-
-        if not pairs:
-            raise RuntimeError("[collapse] No non-empty corrected BED inputs discovered.")
-
-        return pairs, upstream_sigs, mode
+        return collect_upstream_pairs(
+            "collapse",
+            self.upstreams,
+            self.run_id,
+            "all_corrected.bed",
+            "{chrom}_{start}_{end}_all_corrected.bed",
+            file_check=lambda p: p.exists() and not bed_is_empty(p),
+        )
 
     def build_cmds(self) -> List[List[str]]:
         cfg = self.cfg
@@ -107,34 +79,16 @@ class CollapseStage(StageBase):
         ]
         self._flags_components = flag_parts
 
-        cmds: List[List[str]] = []
-
-        if mode == "regionalized":
-            for bed, tag in bed_pairs:
-                cmds.append(
-                    make_flair_cmd(
-                        "collapse",
-                        bed=bed,
-                        genome=genome,
-                        reads=reads,
-                        out=tag,
-                        flags=flag_parts,
-                    )
-                )
-                logging.info(f"[collapse] Scheduled per-region collapse: {tag}")
-        else:
-            bed, _ = bed_pairs[0]
-            cmds.append(
-                make_flair_cmd(
-                    "collapse",
-                    bed=bed,
-                    genome=genome,
-                    reads=reads,
-                    out=self.run_id,
-                    flags=flag_parts,
-                )
-            )
-            logging.info(f"[collapse] Scheduled standard collapse: {self.run_id}")
+        cmds = build_flair_cmds(
+            "collapse",
+            bed_pairs,
+            genome,
+            reads,
+            self.run_id,
+            flag_parts,
+            regionalized=(mode == "regionalized"),
+            use_bed=True,
+        )
 
         logging.debug(f"[collapse] mode={mode} commands={len(cmds)}")
         return cmds
@@ -149,30 +103,11 @@ class CollapseStage(StageBase):
         - Regionalized: first region tag’s isoforms.bed
         - Standard: run_id.isoforms.bed
         """
-        if "regionalize" in self.upstreams:
-            # If build_cmds hasn't run yet, fall back to a reasonable default
-            first = self._first_tag or f"{self.run_id}"
-            return {
-                "isoforms_bed": Path(f"{first}.isoforms.bed"),
-                "isoforms_gtf": Path(f"{first}.isoforms.gtf"),
-                # (Optional) Pattern hint for humans; Reinstate shouldn't rely on this:
-                "isoforms_bed_pattern": Path("{chrom}_{start}_{end}.isoforms.bed"),
-            }
-        else:
-            base = self.run_id
-            return {
-                "isoforms_bed": Path(f"{base}.isoforms.bed"),
-                "isoforms_gtf": Path(f"{base}.isoforms.gtf"),
-            }
+        return isoform_expected_outputs(
+            self.run_id,
+            self._first_tag,
+            regionalized=(self._mode == "regionalized"),
+        )
 
     def _run_qc(self, stage_dir: Path, primary: Path, runtime: float | None) -> dict:
-        qc: dict = {}
-        try:
-            from ..qc.ted import collect as ted_collect
-
-            ted_collect(stage_dir, self.cfg, upstreams=self.upstreams)
-            qc["TED"] = {"tsv": str(stage_dir / "TED.tsv")}
-
-        except Exception as e:
-            logging.warning(f"[collapse] TED QC failed: {e}")
-        return qc
+        return run_ted_qc(self.name, stage_dir, self.cfg, self.upstreams)

--- a/tests/test_stage_utils_refactors.py
+++ b/tests/test_stage_utils_refactors.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from flair_test_suite.stages.stage_utils import (
+    collect_upstream_pairs,
+    isoform_expected_outputs,
+    build_flair_cmds,
+)
+from flair_test_suite.lib.paths import PathBuilder
+
+
+def test_collect_upstream_pairs_standard(tmp_path):
+    run_id = "run1"
+    align_pb = PathBuilder(tmp_path, run_id, "align", "sigA")
+    align_pb.stage_dir.mkdir(parents=True, exist_ok=True)
+    bed = align_pb.stage_dir / f"{run_id}_flair.bed"
+    bed.write_text("bed\n")
+
+    pairs, sigs, mode = collect_upstream_pairs(
+    "correct", {"align": align_pb}, run_id, "flair.bed", "{chrom}_{start}_{end}.bed"
+    )
+    assert pairs == [(bed, run_id)]
+    assert sigs == [align_pb.signature]
+    assert mode == "standard"
+
+
+def test_collect_upstream_pairs_regionalized(tmp_path):
+    run_id = "run1"
+    reg_pb = PathBuilder(tmp_path, run_id, "regionalize", "sigR")
+    corr_pb = PathBuilder(tmp_path, run_id, "correct", "sigC")
+    reg_pb.stage_dir.mkdir(parents=True, exist_ok=True)
+    corr_pb.stage_dir.mkdir(parents=True, exist_ok=True)
+    # region details
+    (reg_pb.stage_dir / "region_details.tsv").write_text("chrom\tstart\tend\nchr1\t0\t10\n")
+    bed = corr_pb.stage_dir / "chr1_0_10_all_corrected.bed"
+    bed.write_text("bed\n")
+
+    pairs, sigs, mode = collect_upstream_pairs(
+        "collapse",
+        {"regionalize": reg_pb, "correct": corr_pb},
+        run_id,
+        "all_corrected.bed",
+        "{chrom}_{start}_{end}_all_corrected.bed",
+        file_check=lambda p: p.exists(),
+    )
+    assert pairs == [(bed, "chr1_0_10")]
+    assert set(sigs) == {reg_pb.signature, corr_pb.signature}
+    assert mode == "regionalized"
+
+
+def test_isoform_expected_outputs():
+    std = isoform_expected_outputs("run1", None, False)
+    assert std["isoforms_bed"] == Path("run1.isoforms.bed")
+    reg = isoform_expected_outputs("run1", "chr1_0_10", True)
+    assert reg["isoforms_bed"] == Path("chr1_0_10.isoforms.bed")
+    assert "isoforms_bed_pattern" in reg
+
+
+def test_build_flair_cmds_basic(tmp_path):
+    pairs = [(Path("in.bed"), "tag")]
+    cmds = build_flair_cmds(
+        "collapse",
+        pairs,
+        Path("gen.fa"),
+        [Path("reads.fa")],
+        "run1",
+        ["--foo"],
+        regionalized=False,
+        use_bed=True,
+    )
+    assert cmds == [["flair", "collapse", "-g", "gen.fa", "-r", "reads.fa", "-q", "in.bed", "-o", "run1", "--foo"]]


### PR DESCRIPTION
## Summary
- add shared helpers for upstream discovery, isoform outputs, TED QC, and FLAIR command building
- simplify collapse, correct, and transcriptome stages to use new utilities
- test new stage utilities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7642a54008327abc865726fedba5e