### PR TITLE
Handle large regions without skipping td output

### DIFF
--- a/tests/test_transcriptome_browser.py
+++ b/tests/test_transcriptome_browser.py
@@ -40,40 +40,16 @@ class DummyTree:  # pragma: no cover - behaviour irrelevant
 intervaltree.IntervalTree = DummyTree
 sys.modules.setdefault("intervaltree", intervaltree)
 
-from pathlib import Path
-
-from flair_test_suite.plotting.transcriptome_browser import (
-    _parse_region,
-    Config,
-    generate,
-)
+from flair_test_suite.plotting.transcriptome_browser import _parse_region
 
 
 def test_parse_region_basic():
-    assert _parse_region("chr1:100-200") == ("chr1", 100, 200)
+    assert _parse_region("chr1:100-200") == (("chr1", 100, 200), False)
 
 
 def test_parse_region_with_dash_in_chrom():
-    assert _parse_region("chr1-2_random:100-200") == ("chr1-2_random", 100, 200)
+    assert _parse_region("chr1-2_random:100-200") == (("chr1-2_random", 100, 200), False)
 
 
 def test_parse_region_too_long():
-    assert _parse_region("chr1:100-25000") is None
-
-
-def test_generate_skips_large_region(monkeypatch):
-    cfg = Config(gtf=Path("dummy.gtf"))
-
-    called = False
-
-    def fake_alignment_file(*args, **kwargs):  # pragma: no cover - behaviour irrelevant
-        nonlocal called
-        called = True
-        raise AssertionError("AlignmentFile should not be called for large region")
-
-    from flair_test_suite.plotting import transcriptome_browser as tb
-
-    monkeypatch.setattr(tb.pysam, "AlignmentFile", fake_alignment_file, raising=False)
-
-    generate(cfg, region="chr1:0-25000")
-    assert not called
+    assert _parse_region("chr1:100-25000") == (("chr1", 100, 25000), True)


### PR DESCRIPTION
## Summary
- flag regions exceeding 20kb so plotting is skipped but the rest of the transcriptome browser runs
- support skip-plot logic in `generate` and update tests accordingly

## Testing
- `pip install -q --break-system-packages pytest` *(fails: Could not find a version that satisfies the requirement pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68a7954f70d8832786538f7666244a39