### PR TITLE
feat: support structured combine manifest

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -126,4 +126,34 @@ requires = ["regionalize"]
                   # Note : No flags, so default settings for collapse used
 ```
 
+## Combine stage manifest
+
+The `combine` stage merges multiple transcriptomes using a manifest TSV.
+By default the stage scans the collapse output directory and adds any
+`<sample>.isoforms.bed` files it finds, along with matching FASTA
+(`*.isoforms.fa`) and read-map (`*.isoform.read.map.txt`) files when
+present. Additional samples can be supplied via the `manifest` entry in
+`[run.stages.flags]`:
+
+```toml
+[[run.stages]]
+name = "combine"
+requires = ["collapse"]
+
+[run.stages.flags]
+[[run.stages.flags.manifest]]
+sample = "sample2"
+type = "isoform"
+bed = "sample2.isoforms.bed"
+fasta = "sample2.isoforms.fa"    # optional
+# read_map = "sample2.isoform.read.map.txt"  # optional
+```
+
+Each manifest row has five tab-separated columns:
+
+``sample`` `type` `bed` `fasta` `read_map`
+
+Paths are resolved relative to `data_dir`. Leave `fasta` and
+`read_map` blank if those files are unavailable.
+
 For more details, see the [FLAIR Test Suite Overview](./overview.md).


### PR DESCRIPTION
## Summary
- auto-discover collapse outputs and build full FLAIR combine manifest
- allow manifest entries from config with sample/type/fasta/read-map
- document combine manifest format and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c357f69c83278c1b4689e09b4618