### PR TITLE
Organize TED and SQANTI QC outputs

### DIFF
--- a/docs/simulation_test.md
+++ b/docs/simulation_test.md
@@ -154,8 +154,10 @@ A testing pipeline to:
 │               │       │       └── *.isoforms.bed
 │               │       │
 │               │       ├── collapse_qc/         # FLAIR collapse QC for this region across all runs 
-│               │       │   ├── sqanti_summary.tsv
-│               │       │   ├── sqanti.png
+│               │       │   ├── qc/
+│               │       │   │   └── sqanti/
+│               │       │       ├── sqanti_results.tsv
+│               │       │       └── sqanti.png
 │               │       │   ├── ted_summary.tsv
 │               │       │   ├── ted.png
 │               │       │   └── region_metrics.png

--- a/src/flair_test_suite/plotting/sqanti_plot.py
+++ b/src/flair_test_suite/plotting/sqanti_plot.py
@@ -84,10 +84,11 @@ def main():
         print(f"Plotting {tsv} → {plot_dir}")
         plot_summary(tsv, plot_dir)
     else:
-        pattern = os.path.join(args.outdir,'results','*','*','sqanti_results.tsv')
+        pattern = os.path.join(args.outdir,'results','*','*','qc','sqanti','sqanti_results.tsv')
         for tsv in sorted(glob.glob(pattern)):
-            region = os.path.basename(os.path.dirname(os.path.dirname(tsv)))
-            runn   = os.path.basename(os.path.dirname(tsv))
+            parts = os.path.normpath(tsv).split(os.sep)
+            region = parts[-5]
+            runn   = parts[-4]
             plot_dir = os.path.join(args.outdir,'plots',region,runn)
             print(f"Plotting {tsv} → {plot_dir}")
             plot_summary(tsv, plot_dir)

--- a/src/flair_test_suite/plotting/transcriptome_browser.py
+++ b/src/flair_test_suite/plotting/transcriptome_browser.py
@@ -188,8 +188,12 @@ def _parse_region(region: Optional[str]) -> Tuple[Optional[Tuple[str, int, int]]
     return (chrom, start_i, end_i), False
 
 
-def generate(cfg: Config, region: Optional[str] = None) -> None:
-    """Generate plot from configuration (reads + isoform bars only)."""
+def generate(cfg: Config, region: Optional[str] = None) -> Optional[Path]:
+    """Generate plot from configuration (reads + isoform bars only).
+
+    Returns the Path to the saved PNG on success, or ``None`` if the plot was
+    skipped (e.g., due to missing inputs).
+    """
     region_tuple, skip_plot = _parse_region(region)
     # If region string was supplied but couldn't be parsed, bail out
     if region and region_tuple is None:
@@ -532,13 +536,14 @@ def generate(cfg: Config, region: Optional[str] = None) -> None:
     # save
     if skip_plot:
         plt.close(fig)
-        return
+        return None
     out_png = outdir / f"{genome}_{contig}_{xmin}-{xmax}.png"
     fig.savefig(out_png, dpi=fig.dpi)
     plt.close(fig)
     width_px, height_px = int(fig_w * fig.dpi), int(fig_h * fig.dpi)
     print(f"Figure dimensions: {width_px} x {height_px} pixels")
     print(f"Saved: {out_png}")
+    return out_png
 
 
 def main():

--- a/tests/test_ted_nonregionalized.py
+++ b/tests/test_ted_nonregionalized.py
@@ -82,14 +82,15 @@ def test_collect_single_resolves_peaks(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
 
-    ted.collect(stage_dir, cfg)
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, out_dir=out_dir)
 
     assert captured["prime5"] == data_dir / "exp5.bed"
     assert captured["prime3"] == data_dir / "exp3.bed"
     assert captured["ref_prime5"] == data_dir / "ref5.bed"
     assert captured["ref_prime3"] == data_dir / "ref3.bed"
 
-    df = pd.read_csv(stage_dir / "TED.tsv", sep="\t")
+    df = pd.read_csv(out_dir / "TED.tsv", sep="\t")
     assert df.loc[0, "5prime_precision"] == 0.1
     assert df.loc[0, "3prime_precision"] == 0.2
     assert df.loc[0, "ref5prime_precision"] == 0.3
@@ -137,7 +138,8 @@ def test_collect_single_uses_run_level_inputs(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
 
-    ted.collect(stage_dir, cfg)
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, out_dir=out_dir)
 
     assert captured["prime5"] == data_dir / "exp5.bed"
     assert captured["prime3"] == data_dir / "exp3.bed"
@@ -193,7 +195,8 @@ def test_collect_single_uses_stage_flags(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
 
-    ted.collect(stage_dir, cfg)
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, out_dir=out_dir)
 
     assert captured["prime5"] == data_dir / "exp5.bed"
     assert captured["prime3"] == data_dir / "exp3.bed"

--- a/tests/test_ted_regionalized.py
+++ b/tests/test_ted_regionalized.py
@@ -80,14 +80,15 @@ def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
 
     reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
-    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb})
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb}, out_dir=out_dir)
 
     assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
     assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
     assert captured['ref_prime5'] == reg_dir / f'{tag}_ref5.bed'
     assert captured['ref_prime3'] == reg_dir / f'{tag}_ref3.bed'
 
-    df = pd.read_csv(stage_dir / 'TED.tsv', sep='\t')
+    df = pd.read_csv(out_dir / 'TED.tsv', sep='\t')
     assert df.loc[0, '5prime_precision'] == 0.1
     assert df.loc[0, '3prime_precision'] == 0.2
     assert df.loc[0, 'ref5prime_precision'] == 0.3
@@ -142,7 +143,8 @@ def test_collect_regionalized_uses_run_level_inputs(tmp_path: Path, monkeypatch)
     monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
 
     reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
-    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb})
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb}, out_dir=out_dir)
 
     assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
     assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
@@ -199,7 +201,8 @@ def test_collect_regionalized_uses_stage_flags(tmp_path: Path, monkeypatch):
     monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
 
     reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
-    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb})
+    out_dir = stage_dir / 'qc' / 'ted'
+    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb}, out_dir=out_dir)
 
     assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
     assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'


### PR DESCRIPTION
## Summary
- namespace TED and SQANTI outputs under `qc/ted` and `qc/sqanti`
- capture transcriptome browser PNG paths and record region mapping
- update reinstate and plotting utilities for new QC layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68adf9ba74f88327b5bf7dee63268876