### PR TITLE
Standardize QC layout for single-stream stages

### DIFF
--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -81,6 +81,10 @@ experiment_3_prime_regions_bed_file = ""                          # optional
 reference_5_prime_regions_bed_file  = ""                          # optional
 reference_3_prime_regions_bed_file  = ""                          # optional
 
+# The four *regions_bed_file fields above must be specified here under the
+# shared run-level inputs.  Stage flags and QC blocks are no longer consulted
+# for these peak files.
+
 # ------------------------------------------------------------------------------------------------------------
 # -------- ALIGN ------------------------------------------------------
 # ------------------------------------------------------------------------------------------------------------

--- a/src/flair_test_suite/plotting/align_histograms.py
+++ b/src/flair_test_suite/plotting/align_histograms.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Sequence, Dict
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def _hist(vals: Sequence[float] | Sequence[int], out: Path, xlabel: str) -> str | None:
+    if not vals:
+        return None
+    plt.figure()
+    plt.hist(vals, bins=50)
+    plt.xlabel(xlabel)
+    plt.ylabel("count")
+    plt.tight_layout()
+    plt.savefig(out, dpi=150)
+    plt.close()
+    return out.name
+
+
+def generate_histograms(
+    mapq_vals: Sequence[int],
+    identity_vals: Sequence[float],
+    read_len_vals: Sequence[int],
+    out_dir: Path,
+) -> Dict[str, str | None]:
+    """Generate align QC histograms and return mapping of type->filename."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+    mapping: Dict[str, str | None] = {}
+    mapping["mapq"] = _hist(mapq_vals, out_dir / "align_mapq_hist.png", "MAPQ")
+    mapping["identity"] = _hist(identity_vals, out_dir / "align_identity_hist.png", "Read identity (%)")
+    mapping["length"] = _hist(read_len_vals, out_dir / "align_length_hist.png", "Read length (bp)")
+    return mapping

--- a/src/flair_test_suite/qc/__init__.py
+++ b/src/flair_test_suite/qc/__init__.py
@@ -47,6 +47,7 @@ def write_metrics(stage_dir: Path, stage_name: str, metrics: dict):
       ...
     """
     out_f = qc_sidecar_path(stage_dir, stage_name)
+    out_f.parent.mkdir(parents=True, exist_ok=True)
     with open(out_f, "w", newline="") as fh:
         w = csv.writer(fh, delimiter="\t")
         w.writerow(["metric", "value"])

--- a/src/flair_test_suite/stages/align.py
+++ b/src/flair_test_suite/stages/align.py
@@ -12,12 +12,12 @@ from pathlib import Path # for filesystem paths
 
 from .base import StageBase       # base class providing orchestration logic
 
-from .stage_utils import count_reads, make_flair_cmd
+from .stage_utils import estimate_read_count, make_flair_cmd
 
 class AlignStage(StageBase):
     name = "align"
 
-    def build_cmd(self) -> list[str]:
+    def build_cmds(self) -> list[list[str]]:
         cfg = self.cfg
 
         # --- resolve input paths ---
@@ -36,9 +36,15 @@ class AlignStage(StageBase):
         ]
         self._genome_fa_abs = str(genome)
 
-        # --- count reads across all files ---
-        total_reads = sum(count_reads(r) for r in resolved_reads)
-        self._n_input_reads = total_reads
+        # --- estimate reads across all files ---
+        total = 0
+        all_exact = True
+        for r in resolved_reads:
+            cnt, exact = estimate_read_count(r)
+            total += cnt
+            all_exact &= exact
+        self._n_input_reads = total
+        self._read_count_method = "exact" if all_exact else "estimated"
         if self._n_input_reads == 0:
             logging.warning(f"No reads counted in any input files: {resolved_reads}")
 
@@ -71,13 +77,14 @@ class AlignStage(StageBase):
         # Flair expects one -r arg with comma-separated files
         reads_arg = ",".join(str(r) for r in resolved_reads)
 
-        return make_flair_cmd(
+        cmd = make_flair_cmd(
             "align",
             genome=genome,
-            reads=reads_arg,   # <--- now a single string: file1,file2
+            reads=reads_arg,
             out=out_prefix,
             flags=flag_parts,
         )
+        return [cmd]
 
 
     @property
@@ -99,7 +106,3 @@ class AlignStage(StageBase):
     # QC is invoked automatically by StageBase if a collector is registered
     def collect_qc(self, pb):
         return {}  # no-op here; actual QC logic lives in qc/align_qc.py
-
-    def build_cmds(self) -> list[list[str]] | None:
-        """Return None as AlignStage uses a single command."""
-        return None

--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -94,10 +94,6 @@ class CollapseStage(StageBase):
         logging.debug(f"[collapse] mode={mode} commands={len(cmds)}")
         return cmds
 
-    def build_cmd(self) -> list[str]:
-        cmds = self.build_cmds()
-        return cmds[-1] if cmds else []
-
     def expected_outputs(self) -> dict[str, Path]:
         """
         Provide a CONCRETE primary so Reinstate can test existence.

--- a/src/flair_test_suite/stages/combine.py
+++ b/src/flair_test_suite/stages/combine.py
@@ -50,7 +50,7 @@ class CombineStage(StageBase):
     def tool_version(self) -> str:  # pragma: no cover - simple accessor
         return str(self.cfg.run.version)
 
-    def build_cmd(self) -> List[str]:
+    def build_cmds(self) -> List[List[str]]:
         cfg = self.cfg
         stage_cfg = get_stage_config(cfg, self.name)
         raw_flags = dict(getattr(stage_cfg, "flags", {}) or {})
@@ -125,10 +125,7 @@ class CombineStage(StageBase):
 
         cmd = ["flair", "combine", "--manifest", self._manifest_rel, "-o", self.run_id]
         cmd.extend(flag_parts)
-        return cmd
-
-    def build_cmds(self) -> List[List[str]] | None:  # pragma: no cover - single command
-        return None
+        return [cmd]
 
     def expected_outputs(self) -> dict[str, Path]:
         # FLAIR combine produces several artifacts: a merged BED, counts TSV,

--- a/src/flair_test_suite/stages/quantify.py
+++ b/src/flair_test_suite/stages/quantify.py
@@ -60,7 +60,7 @@ class QuantifyStage(StageBase):
         raise RuntimeError("[quantify] isoform FASTA not found in upstream outputs")
 
     # ------------------------------------------------------------------
-    def build_cmd(self) -> List[str]:
+    def build_cmds(self) -> List[List[str]]:
         cfg = self.cfg
         stage_cfg = get_stage_config(cfg, self.name)
         raw_flags = dict(getattr(stage_cfg, "flags", {}) or {})
@@ -119,10 +119,7 @@ class QuantifyStage(StageBase):
             self.run_id,
         ]
         cmd.extend(flag_parts)
-        return cmd
-
-    def build_cmds(self) -> List[List[str]] | None:  # pragma: no cover - single command
-        return None
+        return [cmd]
 
     # ------------------------------------------------------------------
     def expected_outputs(self) -> dict[str, Path]:

--- a/src/flair_test_suite/stages/regionalize.py
+++ b/src/flair_test_suite/stages/regionalize.py
@@ -97,7 +97,7 @@ class RegionalizeStage(StageBase):
             except Exception:
                 self._genome_fa_abs = None
 
-        # Optional inputs (slice per region)
+        # Optional inputs (slice per region) sourced solely from run-level config
         opt_keys = [
             "junctions",  # STAR SJ.out.tab
             "experiment_5_prime_regions_bed_file",
@@ -107,7 +107,7 @@ class RegionalizeStage(StageBase):
         ]
         self._optional: Dict[str, Path] = {}
         for k in opt_keys:
-            v = getattr(cfg.run, k, None) or flags.get(k)
+            v = getattr(cfg.run, k, None)
             if v:
                 p = resolve_path(v, data_dir=data_dir)
                 self._optional[k] = p
@@ -212,10 +212,6 @@ class RegionalizeStage(StageBase):
 
 
     # for legacy callers
-    def build_cmd(self) -> List[str]:
-        cmds = self.build_cmds()
-        return cmds[0] if cmds else []
-
     def expected_outputs(self) -> dict[str, Path]:
         return {
             "region_bam": Path("{chrom}_{start}_{end}.bam"),

--- a/src/flair_test_suite/stages/transcriptome.py
+++ b/src/flair_test_suite/stages/transcriptome.py
@@ -113,10 +113,6 @@ class TranscriptomeStage(StageBase):
         return cmds
 
     # Legacy shim
-    def build_cmd(self) -> list[str]:
-        cmds = self.build_cmds()
-        return cmds[-1] if cmds else []
-
     # ───────────────────── expected outputs ─────────────────────
     def expected_outputs(self) -> dict[str, Path]:
         """

--- a/tests/test_align_plotting.py
+++ b/tests/test_align_plotting.py
@@ -1,0 +1,69 @@
+from pathlib import Path
+import json
+import types
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+pytest.importorskip("pysam")
+
+from flair_test_suite.plotting.align_histograms import generate_histograms
+from flair_test_suite.qc import align_qc
+
+
+def test_generate_histograms(tmp_path):
+    out = tmp_path / "plots"
+    mapping = generate_histograms([1, 2], [50.0, 60.0], [100, 200], out)
+    assert (out / mapping["mapq"]).exists()
+    assert (out / mapping["identity"]).exists()
+    assert (out / mapping["length"]).exists()
+
+
+def test_align_qc_delegates_plotting(tmp_path, monkeypatch):
+    bam = tmp_path / "in.bam"
+    bam.touch()
+    bed = tmp_path / "in.bed"
+    bed.write_text("chr1\t0\t1\t.\n")
+
+    # stub external calls
+    def fake_run(args, check=True, stdout=None, stderr=None):
+        if "-o" in args:
+            out = Path(args[args.index("-o") + 1])
+            out.write_text("MAPQ\t10\t1\nRL\t100\t1\n")
+        return None
+
+    monkeypatch.setattr(
+        align_qc,
+        "subprocess",
+        types.SimpleNamespace(run=fake_run, CalledProcessError=Exception, DEVNULL=None),
+    )
+    monkeypatch.setattr(align_qc, "iter_primary", lambda *a, **k: [])
+    monkeypatch.setattr(align_qc, "count_unique_junctions", lambda *a, **k: 0)
+    monkeypatch.setattr(align_qc, "count_splice_junction_motifs", lambda *a, **k: {})
+    class DummyAF:
+        def __enter__(self):
+            return object()
+        def __exit__(self, *a):
+            return False
+
+    monkeypatch.setattr(align_qc, "pysam", types.SimpleNamespace(AlignmentFile=lambda *a, **k: DummyAF()))
+
+    called = {}
+
+    def fake_generate(mapq, ident, length, out_dir):
+        called["out_dir"] = out_dir
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return {"mapq": "a.png", "identity": "b.png", "length": "c.png"}
+
+    monkeypatch.setattr(align_qc, "generate_histograms", fake_generate)
+
+    metrics = align_qc.collect(bam, tmp_path, n_input_reads=10, genome_fa="gen.fa", runtime_sec=1.0, read_count_method="estimated")
+    qc_dir = tmp_path / "qc"
+    assert called["out_dir"] == qc_dir
+    manifest = qc_dir / "align_plot_manifest.json"
+    assert manifest.exists()
+    data = json.loads(manifest.read_text())
+    assert data["mapq"] == "a.png"
+    assert metrics["read_count_method"] == "estimated"

--- a/tests/test_combine_stage.py
+++ b/tests/test_combine_stage.py
@@ -60,7 +60,7 @@ def test_combine_writes_manifest_and_builds_cmd(tmp_path, monkeypatch):
         cfg, run_id="run1", work_dir=repo_root / "outputs", upstreams={"collapse": collapse_pb}
     )
 
-    cmd = stage.build_cmd()
+    cmd = stage.build_cmds()[0]
     assert cmd[:3] == ["flair", "combine", "--manifest"]
     assert cmd[3] == "manifest.tsv"
     assert cmd[4:6] == ["-o", "run1"]
@@ -118,7 +118,7 @@ def test_combine_defaults_to_collapse_output(tmp_path, monkeypatch):
 
     stage = CombineStage(cfg, run_id="run1", work_dir=repo_root / "outputs", upstreams={"collapse": collapse_pb})
 
-    cmd = stage.build_cmd()
+    cmd = stage.build_cmds()[0]
     assert cmd[:3] == ["flair", "combine", "--manifest"]
     assert cmd[3] == "manifest.tsv"
     assert cmd[4:6] == ["-o", "run1"]

--- a/tests/test_estimate_read_count.py
+++ b/tests/test_estimate_read_count.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import gzip
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from flair_test_suite.stages.stage_utils import estimate_read_count
+
+def _write_fastq(path: Path, n: int):
+    with gzip.open(path, "wt") as fh:
+        for i in range(n):
+            fh.write(f"@r{i}\nAAA\n+\nIII\n")
+
+
+def test_estimate_read_count_exact(tmp_path):
+    fq = tmp_path / "reads.fastq.gz"
+    _write_fastq(fq, 10)
+    count, exact = estimate_read_count(fq, max_reads=50)
+    assert count == 10 and exact
+
+
+def test_estimate_read_count_estimated(tmp_path):
+    fq = tmp_path / "reads.fastq.gz"
+    _write_fastq(fq, 1000)
+    count, exact = estimate_read_count(fq, max_reads=50)
+    assert not exact
+    assert count > 0

--- a/tests/test_qc_dummy.py
+++ b/tests/test_qc_dummy.py
@@ -20,7 +20,7 @@ def test_qc_registry_has_expected_collectors():
 def test_write_metrics_creates_tsv(tmp_path: Path):
     metrics = {"one": 1, "two": "dos"}
     qc.write_metrics(tmp_path, "dummy", metrics)
-    out = tmp_path / "dummy_qc.tsv"
+    out = tmp_path / "qc" / "dummy_qc.tsv"
     assert out.exists()
     lines = out.read_text().splitlines()
     assert lines[0] == "metric\tvalue"

--- a/tests/test_quantify_stage.py
+++ b/tests/test_quantify_stage.py
@@ -54,7 +54,7 @@ def test_quantify_uses_manifest_and_cmd(tmp_path, monkeypatch):
         cfg, run_id="run1", work_dir=repo_root / "outputs", upstreams={"collapse": collapse_pb}
     )
 
-    cmd = stage.build_cmd()
+    cmd = stage.build_cmds()[0]
     assert cmd[:3] == ["flair", "quantify", "-r"]
     assert Path(cmd[3]).name == "reads_manifest.tsv"
     assert "-i" in cmd and str(iso_fa) in cmd

--- a/tests/test_ted_nonregionalized.py
+++ b/tests/test_ted_nonregionalized.py
@@ -1,11 +1,9 @@
+import types
 import sys
 from pathlib import Path
-import types
 
-import pandas as pd
 import pytest
 
-# Make package importable
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 sys.modules.setdefault("intervaltree", types.SimpleNamespace(IntervalTree=object))
@@ -15,120 +13,42 @@ from flair_test_suite.config_schema import Config as Cfg
 from flair_test_suite.qc import ted
 
 
-def test_collect_single_resolves_peaks(tmp_path: Path, monkeypatch):
-    repo_root = tmp_path
-    data_dir = repo_root / "test_data"
+def _make_cfg(tmp_path: Path, with_peaks: bool = True) -> Cfg:
+    data_dir = tmp_path / "test_data"
     data_dir.mkdir()
     for name in ["exp5.bed", "exp3.bed", "ref5.bed", "ref3.bed"]:
         (data_dir / name).write_text("chr1\t0\t1\t.\t0\t+\n")
 
-    run_id = "run1"
-    stage_uuid = "123abc"
-    stage_dir = repo_root / "outputs" / run_id / "collapse" / stage_uuid
-    stage_dir.mkdir(parents=True)
-
-    iso_bed = stage_dir / f"{run_id}.isoforms.bed"
-    iso_bed.write_text("chr1\t100\t200\tread_ENSG000001.1\t0\t+\n")
-    map_txt = stage_dir / f"{run_id}.isoform.read.map.txt"
-    map_txt.write_text(f"{iso_bed.stem}\tread1,read2\n")
-
-    corr_dir = repo_root / "outputs" / run_id / "correct" / "abcd"
-    corr_dir.mkdir(parents=True)
-    (corr_dir / f"{run_id}_all_corrected.bed").write_text(
-        "chr1\t100\t200\tread_ENSG000001.1\t0\t+\n"
-    )
-
-    cfg_dict = {
-        "run_id": run_id,
-        "run": {
-            "version": "1",
-            "conda_env": "env",
-            "work_dir": "outputs",
-            "data_dir": "test_data",
-            "stages": [{"name": "collapse", "requires": []}],
-        },
-        "qc": {
-            "collapse": {
-                "TED": {
-                    "experiment_5_prime_regions_bed_file": "exp5.bed",
-                    "experiment_3_prime_regions_bed_file": "exp3.bed",
-                    "reference_5_prime_regions_bed_file": "ref5.bed",
-                    "reference_3_prime_regions_bed_file": "ref3.bed",
-                    "window": 10,
-                }
+    run_cfg = {
+        "version": "1",
+        "conda_env": "env",
+        "work_dir": "outputs",
+        "data_dir": "test_data",
+        "stages": [{"name": "collapse", "requires": []}],
+    }
+    if with_peaks:
+        run_cfg.update(
+            {
+                "experiment_5_prime_regions_bed_file": "exp5.bed",
+                "experiment_3_prime_regions_bed_file": "exp3.bed",
+                "reference_5_prime_regions_bed_file": "ref5.bed",
+                "reference_3_prime_regions_bed_file": "ref3.bed",
             }
-        },
-    }
-    cfg = Cfg.model_validate(cfg_dict)
+        )
 
-    captured = {}
-
-    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
-        captured.update(peaks)
-        return {
-            "5prime_precision": 0.1,
-            "5prime_recall": 0.1,
-            "5prime_f1": 0.1,
-            "3prime_precision": 0.2,
-            "3prime_recall": 0.2,
-            "3prime_f1": 0.2,
-            "ref5prime_precision": 0.3,
-            "ref5prime_recall": 0.3,
-            "ref5prime_f1": 0.3,
-            "ref3prime_precision": 0.4,
-            "ref3prime_recall": 0.4,
-            "ref3prime_f1": 0.4,
-        }
-
-    monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
-
-    out_dir = stage_dir / 'qc' / 'ted'
-    ted.collect(stage_dir, cfg, out_dir=out_dir)
-
-    assert captured["prime5"] == data_dir / "exp5.bed"
-    assert captured["prime3"] == data_dir / "exp3.bed"
-    assert captured["ref_prime5"] == data_dir / "ref5.bed"
-    assert captured["ref_prime3"] == data_dir / "ref3.bed"
-
-    df = pd.read_csv(out_dir / "TED.tsv", sep="\t")
-    assert df.loc[0, "5prime_precision"] == 0.1
-    assert df.loc[0, "3prime_precision"] == 0.2
-    assert df.loc[0, "ref5prime_precision"] == 0.3
-    assert df.loc[0, "ref3prime_precision"] == 0.4
+    cfg_dict = {"run_id": "run1", "run": run_cfg, "qc": {"collapse": {"TED": {"window": 10}}}}
+    return Cfg.model_validate(cfg_dict)
 
 
-def test_collect_single_uses_run_level_inputs(tmp_path: Path, monkeypatch):
-    """When QC block omits peaks, run-level fields supply them."""
+def test_collect_uses_run_level_peaks(tmp_path: Path, monkeypatch):
+    cfg = _make_cfg(tmp_path, with_peaks=True)
     repo_root = tmp_path
-    data_dir = repo_root / "test_data"
-    data_dir.mkdir()
-    for name in ["exp5.bed", "exp3.bed", "ref5.bed", "ref3.bed"]:
-        (data_dir / name).write_text("chr1\t0\t1\t.\t0\t+\n")
-
     run_id = "run1"
     stage_uuid = "123abc"
     stage_dir = repo_root / "outputs" / run_id / "collapse" / stage_uuid
     stage_dir.mkdir(parents=True)
-
     iso_bed = stage_dir / f"{run_id}.isoforms.bed"
     iso_bed.write_text("chr1\t100\t200\tread_ENSG000001.1\t0\t+\n")
-
-    cfg_dict = {
-        "run_id": run_id,
-        "run": {
-            "version": "1",
-            "conda_env": "env",
-            "work_dir": "outputs",
-            "data_dir": "test_data",
-            "experiment_5_prime_regions_bed_file": "exp5.bed",
-            "experiment_3_prime_regions_bed_file": "exp3.bed",
-            "reference_5_prime_regions_bed_file": "ref5.bed",
-            "reference_3_prime_regions_bed_file": "ref3.bed",
-            "stages": [{"name": "collapse", "requires": []}],
-        },
-        "qc": {"collapse": {"TED": {"window": 10}}},
-    }
-    cfg = Cfg.model_validate(cfg_dict)
 
     captured = {}
 
@@ -138,67 +58,25 @@ def test_collect_single_uses_run_level_inputs(tmp_path: Path, monkeypatch):
 
     monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
 
-    out_dir = stage_dir / 'qc' / 'ted'
+    out_dir = stage_dir / "qc" / "ted"
     ted.collect(stage_dir, cfg, out_dir=out_dir)
 
+    data_dir = repo_root / "test_data"
     assert captured["prime5"] == data_dir / "exp5.bed"
     assert captured["prime3"] == data_dir / "exp3.bed"
     assert captured["ref_prime5"] == data_dir / "ref5.bed"
     assert captured["ref_prime3"] == data_dir / "ref3.bed"
 
 
-def test_collect_single_uses_stage_flags(tmp_path: Path, monkeypatch):
-    """If the QC block omits peak paths, fall back to run.stage flags."""
+def test_collect_missing_run_level_peaks_errors(tmp_path: Path, monkeypatch):
+    cfg = _make_cfg(tmp_path, with_peaks=False)
     repo_root = tmp_path
-    data_dir = repo_root / "test_data"
-    data_dir.mkdir()
-    for name in ["exp5.bed", "exp3.bed", "ref5.bed", "ref3.bed"]:
-        (data_dir / name).write_text("chr1\t0\t1\t.\t0\t+\n")
-
     run_id = "run1"
     stage_uuid = "123abc"
     stage_dir = repo_root / "outputs" / run_id / "collapse" / stage_uuid
     stage_dir.mkdir(parents=True)
-
     iso_bed = stage_dir / f"{run_id}.isoforms.bed"
     iso_bed.write_text("chr1\t100\t200\tread_ENSG000001.1\t0\t+\n")
 
-    cfg_dict = {
-        "run_id": run_id,
-        "run": {
-            "version": "1",
-            "conda_env": "env",
-            "work_dir": "outputs",
-            "data_dir": "test_data",
-            "stages": [
-                {
-                    "name": "collapse",
-                    "requires": [],
-                    "flags": {
-                        "experiment_5_prime_regions_bed_file": "exp5.bed",
-                        "experiment_3_prime_regions_bed_file": "exp3.bed",
-                        "reference_5_prime_regions_bed_file": "ref5.bed",
-                        "reference_3_prime_regions_bed_file": "ref3.bed",
-                    },
-                }
-            ],
-        },
-        "qc": {"collapse": {"TED": {"window": 10}}},
-    }
-    cfg = Cfg.model_validate(cfg_dict)
-
-    captured = {}
-
-    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
-        captured.update(peaks)
-        return {}
-
-    monkeypatch.setattr(ted, "_tss_tts_metrics_full", fake_metrics)
-
-    out_dir = stage_dir / 'qc' / 'ted'
-    ted.collect(stage_dir, cfg, out_dir=out_dir)
-
-    assert captured["prime5"] == data_dir / "exp5.bed"
-    assert captured["prime3"] == data_dir / "exp3.bed"
-    assert captured["ref_prime5"] == data_dir / "ref5.bed"
-    assert captured["ref_prime3"] == data_dir / "ref3.bed"
+    with pytest.raises(RuntimeError):
+        ted.collect(stage_dir, cfg, out_dir=stage_dir / "qc" / "ted")

--- a/tests/test_ted_regionalized.py
+++ b/tests/test_ted_regionalized.py
@@ -1,8 +1,7 @@
+import types
 import sys
 from pathlib import Path
-import types
 
-import pandas as pd
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
@@ -15,7 +14,7 @@ from flair_test_suite.lib import PathBuilder
 from flair_test_suite.config_schema import Config as Cfg
 
 
-def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
+def test_collect_regionalized_run_level(tmp_path: Path, monkeypatch):
     repo_root = tmp_path
     data_dir = repo_root / 'test_data'
     data_dir.mkdir()
@@ -43,81 +42,6 @@ def test_collect_regionalized_resolves_peaks(tmp_path: Path, monkeypatch):
     for base in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
         (reg_dir / f'{tag}_{base}').write_text('chr1\t10\t20\t.\t0\t+\n')
 
-    cfg = {
-        'run': {'data_dir': 'test_data'},
-        'qc': {
-            'collapse': {
-                'TED': {
-                    'experiment_5_prime_regions_bed_file': 'exp5.bed',
-                    'experiment_3_prime_regions_bed_file': 'exp3.bed',
-                    'reference_5_prime_regions_bed_file': 'ref5.bed',
-                    'reference_3_prime_regions_bed_file': 'ref3.bed',
-                    'window': 10,
-                }
-            }
-        },
-    }
-
-    captured = {}
-
-    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
-        captured.update(peaks)
-        return {
-            '5prime_precision': 0.1,
-            '5prime_recall': 0.1,
-            '5prime_f1': 0.1,
-            '3prime_precision': 0.2,
-            '3prime_recall': 0.2,
-            '3prime_f1': 0.2,
-            'ref5prime_precision': 0.3,
-            'ref5prime_recall': 0.3,
-            'ref5prime_f1': 0.3,
-            'ref3prime_precision': 0.4,
-            'ref3prime_recall': 0.4,
-            'ref3prime_f1': 0.4,
-        }
-
-    monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
-
-    reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
-    out_dir = stage_dir / 'qc' / 'ted'
-    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb}, out_dir=out_dir)
-
-    assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
-    assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
-    assert captured['ref_prime5'] == reg_dir / f'{tag}_ref5.bed'
-    assert captured['ref_prime3'] == reg_dir / f'{tag}_ref3.bed'
-
-    df = pd.read_csv(out_dir / 'TED.tsv', sep='\t')
-    assert df.loc[0, '5prime_precision'] == 0.1
-    assert df.loc[0, '3prime_precision'] == 0.2
-    assert df.loc[0, 'ref5prime_precision'] == 0.3
-    assert df.loc[0, 'ref3prime_precision'] == 0.4
-
-
-def test_collect_regionalized_uses_run_level_inputs(tmp_path: Path, monkeypatch):
-    """Run-level fields provide peaks when QC config omits them."""
-    repo_root = tmp_path
-    data_dir = repo_root / 'test_data'
-    data_dir.mkdir()
-    for name in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
-        (data_dir / name).write_text('chr1\t0\t1\t.\t0\t+\n')
-
-    run_id = 'run1'
-    stage_uuid = '123abc'
-    stage_dir = repo_root / 'outputs' / run_id / 'collapse' / stage_uuid
-    stage_dir.mkdir(parents=True)
-
-    tag = 'chr1_0_100'
-    iso_bed = stage_dir / f'{tag}.isoforms.bed'
-    iso_bed.write_text('chr1\t10\t50\tread_ENSG000001.1\t0\t+\n')
-
-    reg_dir = repo_root / 'outputs' / run_id / 'regionalize' / 'reg1'
-    reg_dir.mkdir(parents=True)
-    (reg_dir / 'region_metrics.tsv').write_text('region_tag\tgene_count\ttranscript_count\nchr1_0_100\t1\t1\n')
-    for base in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
-        (reg_dir / f'{tag}_{base}').write_text('chr1\t10\t20\t.\t0\t+\n')
-
     cfg_dict = {
         'run': {
             'version': '1',
@@ -133,64 +57,6 @@ def test_collect_regionalized_uses_run_level_inputs(tmp_path: Path, monkeypatch)
         'qc': {'collapse': {'TED': {'window': 10}}},
     }
     cfg = Cfg.model_validate(cfg_dict)
-
-    captured = {}
-
-    def fake_metrics(iso_bed_path, peaks, window, audit_rows, tag_ctx):
-        captured.update(peaks)
-        return {}
-
-    monkeypatch.setattr(ted, '_tss_tts_metrics_full', fake_metrics)
-
-    reg_pb = PathBuilder(repo_root / 'outputs', run_id, 'regionalize', 'reg1')
-    out_dir = stage_dir / 'qc' / 'ted'
-    ted.collect(stage_dir, cfg, upstreams={'regionalize': reg_pb}, out_dir=out_dir)
-
-    assert captured['prime5'] == reg_dir / f'{tag}_exp5.bed'
-    assert captured['prime3'] == reg_dir / f'{tag}_exp3.bed'
-    assert captured['ref_prime5'] == reg_dir / f'{tag}_ref5.bed'
-    assert captured['ref_prime3'] == reg_dir / f'{tag}_ref3.bed'
-
-
-def test_collect_regionalized_uses_stage_flags(tmp_path: Path, monkeypatch):
-    """When QC config omits peaks, run.stage flags supply them."""
-    repo_root = tmp_path
-    data_dir = repo_root / 'test_data'
-    data_dir.mkdir()
-    for name in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
-        (data_dir / name).write_text('chr1\t0\t1\t.\t0\t+\n')
-
-    run_id = 'run1'
-    stage_uuid = '123abc'
-    stage_dir = repo_root / 'outputs' / run_id / 'collapse' / stage_uuid
-    stage_dir.mkdir(parents=True)
-
-    tag = 'chr1_0_100'
-    iso_bed = stage_dir / f'{tag}.isoforms.bed'
-    iso_bed.write_text('chr1\t10\t50\tread_ENSG000001.1\t0\t+\n')
-
-    reg_dir = repo_root / 'outputs' / run_id / 'regionalize' / 'reg1'
-    reg_dir.mkdir(parents=True)
-    (reg_dir / 'region_metrics.tsv').write_text('region_tag\tgene_count\ttranscript_count\nchr1_0_100\t1\t1\n')
-    for base in ['exp5.bed', 'exp3.bed', 'ref5.bed', 'ref3.bed']:
-        (reg_dir / f'{tag}_{base}').write_text('chr1\t10\t20\t.\t0\t+\n')
-
-    cfg = {
-        'run': {
-            'data_dir': 'test_data',
-            'stages': {
-                'collapse': {
-                    'flags': {
-                        'experiment_5_prime_regions_bed_file': 'exp5.bed',
-                        'experiment_3_prime_regions_bed_file': 'exp3.bed',
-                        'reference_5_prime_regions_bed_file': 'ref5.bed',
-                        'reference_3_prime_regions_bed_file': 'ref3.bed',
-                    }
-                }
-            },
-        },
-        'qc': {'collapse': {'TED': {'window': 10}}},
-    }
 
     captured = {}
 


### PR DESCRIPTION
## Summary
- place single-stream QC outputs directly under `<stage>/qc` while keeping subdirs only for TED and SQANTI
- align QC writes plots and metrics to the new location and correct QC reads them from there
- correct stage updates expected outputs and regional QC writing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ae1c8871448327bc5f14544194e96e