### PR TITLE
Improve structured logging for pipeline runs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,13 @@ We're very glad you want to help improve our code. Here's how you can contribute
 
 **Do you want to fix something yourself?** To make improvements to the code directly please fork the repository and add your changes, then create a pull request (don't forget to describe what you did). You can do this even if you're just fixing typos in our documentation, any help is greatly appreciated.
 
+### Logging guidelines
+
+- Use `logging.getLogger(__name__)` in each module and avoid direct use of the root logger.
+- The project formatter records the logger name, so manual prefixes like `[stage]` are unnecessary.
+- Reserve `click.echo` for messages intended for the console; use the logger for run-summary files.
+
 Please don't hesitate to reach out to us via the [forum](https://github.com/BrooksLabUCSC/flair/discussions).
-Thanks! 
+Thanks!
 
 The FLAIR team

--- a/src/flair_test_suite/lib/logging.py
+++ b/src/flair_test_suite/lib/logging.py
@@ -17,7 +17,7 @@ def setup_run_logging(log_path: Path, mode: str = "a", quiet: bool = False) -> N
 
     logging.basicConfig(
         level=logging.INFO,
-        format="%(asctime)s %(levelname)s %(message)s",
+        format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
         handlers=handlers,
     )
 

--- a/src/flair_test_suite/stages/align.py
+++ b/src/flair_test_suite/stages/align.py
@@ -14,6 +14,9 @@ from .base import StageBase       # base class providing orchestration logic
 
 from .stage_utils import estimate_read_count, make_flair_cmd
 
+
+logger = logging.getLogger(__name__)
+
 class AlignStage(StageBase):
     name = "align"
 
@@ -46,7 +49,7 @@ class AlignStage(StageBase):
         self._n_input_reads = total
         self._read_count_method = "exact" if all_exact else "estimated"
         if self._n_input_reads == 0:
-            logging.warning(f"No reads counted in any input files: {resolved_reads}")
+            logger.warning("No reads counted in any input files: %s", resolved_reads)
 
         # --- inputs that affect the signature ---
         self._hash_inputs = resolved_reads + [genome]
@@ -65,11 +68,11 @@ class AlignStage(StageBase):
                 ).strip()
                 self._tool_version = raw.splitlines()[-1] if raw else "flair-unknown"
             except subprocess.CalledProcessError:
-                logging.warning("Could not run `flair --version`; using 'flair-unknown'")
+                logger.warning("Could not run `flair --version`; using 'flair-unknown'")
                 self._tool_version = "flair-unknown"
 
         if not flag_parts:
-            logging.warning("No extra flags configured for align stage; using defaults")
+            logger.warning("No extra flags configured for align stage; using defaults")
 
         # --- construct and return the final command list ---
         out_prefix = f"{self.run_id}_flair"

--- a/src/flair_test_suite/stages/collapse.py
+++ b/src/flair_test_suite/stages/collapse.py
@@ -14,6 +14,9 @@ from .stage_utils import (
     run_ted_qc,
     run_sqanti_qc,
 )
+
+
+logger = logging.getLogger(__name__)
 # Force-load TED QC so Reinstate knows transcriptome has QC
 try:
     from ..qc import ted as _force_import_ted  # noqa: F401
@@ -91,7 +94,7 @@ class CollapseStage(StageBase):
             use_bed=True,
         )
 
-        logging.debug(f"[collapse] mode={mode} commands={len(cmds)}")
+        logger.debug("mode=%s commands=%s", mode, len(cmds))
         return cmds
 
     def expected_outputs(self) -> dict[str, Path]:

--- a/src/flair_test_suite/stages/combine.py
+++ b/src/flair_test_suite/stages/combine.py
@@ -9,6 +9,9 @@ from .base import StageBase
 from .stage_utils import get_stage_config, resolve_path
 
 
+logger = logging.getLogger(__name__)
+
+
 @dataclass
 class ManifestEntry:
     """Representation of one row in the FLAIR combine manifest."""
@@ -81,7 +84,7 @@ class CombineStage(StageBase):
                 )
                 collected += 1
             if collected == 0:
-                logging.debug(f"[combine] no isoforms found in upstream dir {d}")
+                logger.debug("No isoforms found in upstream dir %s", d)
             return collected
 
         collected = 0
@@ -90,17 +93,17 @@ class CombineStage(StageBase):
         if collected == 0:
             # only warn if neither upstream provided any entries; user manifest may still be used
             if collapse_pb or transcriptome_pb:
-                logging.warning(f"[combine] no isoform outputs found in collapse/transcriptome upstreams")
+                logger.warning("No isoform outputs found in collapse/transcriptome upstreams")
 
         # Load user manifest file if provided
         if manifest_src:
             self._user_manifest = resolve_path(manifest_src, data_dir=data_dir)
             if not self._user_manifest.exists():
-                logging.warning(f"[combine] manifest file missing: {self._user_manifest}")
+                logger.warning("Manifest file missing: %s", self._user_manifest)
 
         # Store collapse entries for later appending
         if not entries and not self._user_manifest:
-            raise RuntimeError("[combine] no isoform files found for manifest")
+            raise RuntimeError("no isoform files found for manifest")
 
         self._manifest_entries = entries
 

--- a/src/flair_test_suite/stages/correct.py
+++ b/src/flair_test_suite/stages/correct.py
@@ -11,6 +11,9 @@ from ..qc import write_metrics
 from ..qc.qc_utils import bed_is_empty
 
 
+logger = logging.getLogger(__name__)
+
+
 class CorrectStage(StageBase):
     """
     Runs `flair correct` on either:
@@ -67,7 +70,7 @@ class CorrectStage(StageBase):
         cmds: List[List[str]] = []
         for bed_file, region_tag in self._bed_files:
             if bed_is_empty(bed_file):
-                logging.warning(f"[correct] Skipping missing/empty BED: {bed_file}")
+                logger.warning("Skipping missing/empty BED: %s", bed_file)
                 continue
 
             out_prefix = region_tag

--- a/src/flair_test_suite/stages/transcriptome.py
+++ b/src/flair_test_suite/stages/transcriptome.py
@@ -15,6 +15,9 @@ from .stage_utils import (
     run_sqanti_qc,
 )
 
+
+logger = logging.getLogger(__name__)
+
 # Ensure TED QC is registered for this stage even if QC package isn't imported elsewhere
 try:  # pragma: no cover - best effort, optional dependency
     from ..qc import ted as _force_import_ted  # noqa: F401
@@ -109,7 +112,7 @@ class TranscriptomeStage(StageBase):
             use_bam=True,
         )
 
-        logging.debug(f"[transcriptome] mode={mode} commands={len(cmds)}")
+        logger.debug("mode=%s commands=%s", mode, len(cmds))
         return cmds
 
     # Legacy shim


### PR DESCRIPTION
## Summary
- write run summaries to a single `run_summary.log` without symlinks
- include logger names in log output and use module-level loggers
- document logging conventions for contributors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68af34e157ac83278a81b2cd06c632cd